### PR TITLE
Fixes #2

### DIFF
--- a/dts_validator/client.py
+++ b/dts_validator/client.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 import logging
 import requests
+import random
 from requests.models import Response
 from typing import Optional, Union, List, Tuple, Dict
 from uritemplate import URITemplate
 from .validation import check_required_property
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger()
 
 class DTS_Collection(object):
     """Class representing a DTS Collection object."""
@@ -157,6 +158,7 @@ class DTS_API(object):
     
     def get_one_resource(self):
         collections = self.collections()
+        random.shuffle(collections)
         for collection in collections:
             resource  = get_resource_recursively(collection, self)
             if resource:

--- a/dts_validator/validation.py
+++ b/dts_validator/validation.py
@@ -7,9 +7,7 @@ from jsonschema import validate, RefResolver
 from uritemplate import URITemplate
 from .exceptions import URITemplateMissingParameter, JSONResponseMissingProperty
 
-LOGGER = logging.getLogger()
-
-
+LOGGER = logging.getLogger(__name__)
 
 def validate_json(json_data, json_schema):
     # Set up resolver to correctly handle relative paths

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 log_cli = true
-#log_cli_level = "INFO"
+log_cli_level = "INFO"


### PR DESCRIPTION
Skips tests when the tested `Resource` does not contain any `CitableUnit` (see issue #2).